### PR TITLE
remove second description of the --iso option

### DIFF
--- a/lib/cloudstack-cli/commands/server.rb
+++ b/lib/cloudstack-cli/commands/server.rb
@@ -64,7 +64,7 @@ class Server < CloudstackCli::Base
 
   desc "create NAME [NAME2 ...]", "create server(s)"
   option :template, aliases: '-t', desc: "name of the template"
-  option :iso, desc: "name of the iso", desc: "name of the iso template"
+  option :iso, desc: "name of the iso template"
   option :offering, aliases: '-o', required: true, desc: "computing offering name"
   option :zone, aliases: '-z', required: true, desc: "availability zone name"
   option :networks, aliases: '-n', type: :array, desc: "network names"


### PR DESCRIPTION
This was throwing the following warning:

```
./lib/cloudstack-cli/commands/server.rb:67: warning: duplicated key at line 67 ignored: :desc
```