### PR TITLE
Fix wrong number of arguments

### DIFF
--- a/lib/cloudstack-cli/option_resolver.rb
+++ b/lib/cloudstack-cli/option_resolver.rb
@@ -2,17 +2,17 @@ module CloudstackCli
   module OptionResolver
 
     def vm_options_to_params
-      resolve_zone(options)
-      resolve_project(options)
-      resolve_compute_offering(options)
-      resolve_template(options)
-      resolve_disk_offering(options)
-      resolve_iso(options)
+      resolve_zone
+      resolve_project
+      resolve_compute_offering
+      resolve_template
+      resolve_disk_offering
+      resolve_iso
       unless options[:template_id]
         say "Error: Template or ISO is required.", :red
         exit 1
       end
-      resolve_networks(options)
+      resolve_networks
     end
 
     def resolve_zone


### PR DESCRIPTION
I tried virtual_machine creation command that supported by cloudstack API . However, it failed with the following error message.

```
bundle exec ./bin/cloudstack-cli virtual_machine create server_1 --zone XXX --offering XXX --networks XXX --template XXX
/home/hiracy/repo/cloudstack-cli/lib/cloudstack-cli/option_resolver.rb:18:in `resolve_zone': wrong number of arguments (1 for 0) (ArgumentError)
```

I fixed in this commit and It was succecced.
Could you Check this commit.
